### PR TITLE
Fix gorm logs for our fork to skip internal files

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -134,7 +134,7 @@ func toQueryMarks(primaryValues [][]interface{}) string {
 
 	for _, primaryValue := range primaryValues {
 		var marks []string
-		for _,_ = range primaryValue {
+		for _, _ = range primaryValue {
 			marks = append(marks, "?")
 		}
 
@@ -171,7 +171,9 @@ func toQueryValues(values [][]interface{}) (results []interface{}) {
 func fileWithLineNum() string {
 	for i := 2; i < 15; i++ {
 		_, file, line, ok := runtime.Caller(i)
-		if ok && (!regexp.MustCompile(`jinzhu/gorm/.*.go`).MatchString(file) || regexp.MustCompile(`jinzhu/gorm/.*test.go`).MatchString(file)) {
+		// Skip gorm package files
+		// if ok && (!regexp.MustCompile(`jinzhu/gorm/.*.go`).MatchString(file) || regexp.MustCompile(`jinzhu/gorm/.*test.go`).MatchString(file)) {
+		if ok && (!regexp.MustCompile(`CommonSun/gorm/.*.go`).MatchString(file) || regexp.MustCompile(`CommonSun/gorm/.*test.go`).MatchString(file)) {
 			return fmt.Sprintf("%v:%v", file, line)
 		}
 	}


### PR DESCRIPTION
This will allow us to see the actual file and line number in our own code where the queries are being executed, instead of internal gorm files